### PR TITLE
feat: don't set `-lhermit` by default

### DIFF
--- a/gcc/config/aarch64/hermit.h
+++ b/gcc/config/aarch64/hermit.h
@@ -51,6 +51,6 @@
 #endif
 
 #undef LIB_SPEC
-#define LIB_SPEC "%{pthread:-lpthread} -lc -lg -lm -lhermit"
+#define LIB_SPEC "%{pthread:-lpthread} -lc -lg -lm"
 
 #endif /* GCC_AARCH64_HERMIT_H */

--- a/gcc/config/i386/hermit.h
+++ b/gcc/config/i386/hermit.h
@@ -2,7 +2,7 @@
  * x86_64-hermit-gcc toolchain */
 #undef LIB_SPEC
 #define LIB_SPEC "%{!z:-z max-page-size=0x1000 -z common-page-size=0x1000} \
-		  %{pthread:-lpthread} -lc -lg -lm -lhermit"
+		  %{pthread:-lpthread} -lc -lg -lm"
 
 /* The svr4 ABI for the i386 says that records and unions are returned
  * in memory.  In the 64bit compilation we will turn this flag off in


### PR DESCRIPTION
This removes the default linker flag `-lhermit` to support different linking modes that directly reference the built static library:

```bash
x86_64-hermit-gcc -o main main.c kernel/libhermit.a
```

instead of

```bash
x86_64-hermit-gcc -o main main.c -Lkernel -lhermit
```

This is especially useful once the toolchain does not include `libhermit.a` in the global library path anymore (https://github.com/hermit-os/hermit-gcc/pull/41).