### PR TITLE
feat: unbreak `--enable-default-pie`

### DIFF
--- a/gcc/config/hermit.h
+++ b/gcc/config/hermit.h
@@ -20,7 +20,7 @@
   } while(0);
 
 #undef  STARTFILE_SPEC
-#define STARTFILE_SPEC "crt0.o%s crti.o%s crtbegin.o%s"
+#define STARTFILE_SPEC "crt0%O%s crti%O%s crtbegin%O%s"
 
 #undef  ENDFILE_SPEC
-#define ENDFILE_SPEC "crtend.o%s crtn.o%s"
+#define ENDFILE_SPEC "crtend%O%s crtn%O%s"

--- a/gcc/config/hermit.h
+++ b/gcc/config/hermit.h
@@ -20,7 +20,7 @@
   } while(0);
 
 #undef  STARTFILE_SPEC
-#define STARTFILE_SPEC "crt0%O%s crti%O%s crtbegin%O%s"
+#define STARTFILE_SPEC "crt0%O%s crti%O%s %{static:crtbeginT%O%s;shared|static-pie|" PIE_SPEC ":crtbeginS%O%s;:crtbegin%O%s}"
 
 #undef  ENDFILE_SPEC
-#define ENDFILE_SPEC "crtend%O%s crtn%O%s"
+#define ENDFILE_SPEC "%{shared|static-pie|" PIE_SPEC ":crtendS%O%s;:crtend%O%s} crtn%O%s"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -405,12 +405,6 @@ i[34567]86-*-cygwin* | x86_64-*-cygwin*)
 esac
 
 case ${host} in
-x86_64-*-hermit*)
-	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
-	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
-	tmake_file="${tmake_file} i386/t-crtpc t-crtfm i386/t-crtstuff t-tls t-dfprules"
-	tm_file="${tm_file} i386/elf-lib.h"
-	;;
 aarch64*-*-elf | aarch64*-*-rtems* | aarch64*-*-hermit)
 	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	extra_parts="$extra_parts crtfastmath.o"
@@ -899,6 +893,12 @@ x86_64-*-cygwin*)
 	fi
 	# FIXME - dj - t-chkstk used to be in here, need a 64-bit version of that
 	tmake_file="${tmake_file} ${tmake_eh_file} ${tmake_dlldir_file} i386/t-slibgcc-cygming i386/t-cygming i386/t-cygwin t-crtfm t-dfprules i386/t-chkstk"
+	;;
+x86_64-*-hermit*)
+	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
+	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
+	tmake_file="${tmake_file} i386/t-crtpc t-crtfm i386/t-crtstuff t-tls t-dfprules"
+	tm_file="${tm_file} i386/elf-lib.h"
 	;;
 i[34567]86-*-mingw*)
 	extra_parts="crtbegin.o crtend.o crtfastmath.o"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -312,6 +312,7 @@ case ${host} in
   ;;
 *-*-hermit*)
   tmake_file="$tmake_file t-hermit"
+  extra_parts="crtbegin.o crtend.o crti.o crtn.o"
   ;;
 *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-linux"
@@ -425,7 +426,6 @@ aarch64*-*-freebsd*)
 	md_unwind_header=aarch64/freebsd-unwind.h
 	;;
 aarch64*-*-hermit)
-	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	extra_parts="$extra_parts crtfastmath.o"
 	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
 	tmake_file="${tmake_file} ${cpu_type}/t-lse t-slibgcc-libgcc"
@@ -905,7 +905,6 @@ x86_64-*-cygwin*)
 	tmake_file="${tmake_file} ${tmake_eh_file} ${tmake_dlldir_file} i386/t-slibgcc-cygming i386/t-cygming i386/t-cygwin t-crtfm t-dfprules i386/t-chkstk"
 	;;
 x86_64-*-hermit*)
-	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
 	tmake_file="${tmake_file} i386/t-crtpc t-crtfm i386/t-crtstuff t-tls t-dfprules"
 	tm_file="${tm_file} i386/elf-lib.h"
@@ -1375,7 +1374,7 @@ riscv*-*-linux*)
 	;;
 riscv*-*-freebsd* | riscv*-*-hermit*)
 	tmake_file="${tmake_file} riscv/t-crtstuff riscv/t-softfp${host_address} t-softfp riscv/t-elf riscv/t-elf${host_address} t-slibgcc-libgcc"
-	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o crtendS.o crtbeginT.o"
+	extra_parts="$extra_parts crtendS.o crtbeginT.o"
 	;;
 riscv*-*-*)
 	tmake_file="${tmake_file} riscv/t-softfp${host_address} t-softfp riscv/t-elf riscv/t-elf${host_address}"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -312,7 +312,7 @@ case ${host} in
   ;;
 *-*-hermit*)
   tmake_file="$tmake_file t-hermit"
-  extra_parts="crtbegin.o crtend.o crti.o crtn.o"
+  extra_parts="crtbegin.o crtend.o crtbeginS.o crtbeginT.o crtendS.o crti.o crtn.o"
   ;;
 *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-linux"
@@ -1374,7 +1374,6 @@ riscv*-*-linux*)
 	;;
 riscv*-*-freebsd* | riscv*-*-hermit*)
 	tmake_file="${tmake_file} riscv/t-crtstuff riscv/t-softfp${host_address} t-softfp riscv/t-elf riscv/t-elf${host_address} t-slibgcc-libgcc"
-	extra_parts="$extra_parts crtendS.o crtbeginT.o"
 	;;
 riscv*-*-*)
 	tmake_file="${tmake_file} riscv/t-softfp${host_address} t-softfp riscv/t-elf riscv/t-elf${host_address}"

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -311,7 +311,7 @@ case ${host} in
   extra_parts="crtbegin.o crtend.o"
   ;;
 *-*-hermit*)
-  tmake_file="$tmake_file t-hermit"
+  tmake_file="$tmake_file t-hermit t-crtstuff-pic t-libgcc-pic"
   extra_parts="crtbegin.o crtend.o crtbeginS.o crtbeginT.o crtendS.o crti.o crtn.o"
   ;;
 *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -405,7 +405,7 @@ i[34567]86-*-cygwin* | x86_64-*-cygwin*)
 esac
 
 case ${host} in
-aarch64*-*-elf | aarch64*-*-rtems* | aarch64*-*-hermit)
+aarch64*-*-elf | aarch64*-*-rtems*)
 	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
 	extra_parts="$extra_parts crtfastmath.o"
 	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
@@ -423,6 +423,16 @@ aarch64*-*-freebsd*)
 	tmake_file="${tmake_file} t-dfprules"
 	md_unwind_def_header=aarch64/aarch64-unwind-def.h
 	md_unwind_header=aarch64/freebsd-unwind.h
+	;;
+aarch64*-*-hermit)
+	extra_parts="$extra_parts crtbegin.o crtend.o crti.o crtn.o"
+	extra_parts="$extra_parts crtfastmath.o"
+	tmake_file="${tmake_file} ${cpu_type}/t-aarch64"
+	tmake_file="${tmake_file} ${cpu_type}/t-lse t-slibgcc-libgcc"
+	tmake_file="${tmake_file} ${cpu_type}/t-softfp t-softfp t-crtfm"
+	tmake_file="${tmake_file} t-dfprules"
+	md_unwind_def_header=aarch64/aarch64-unwind-def.h
+	md_unwind_header=aarch64/aarch64-unwind.h
 	;;
 aarch64*-*-netbsd*)
 	extra_parts="$extra_parts crtfastmath.o"


### PR DESCRIPTION
This PR allows compiling GCC for Hermit with `--enable-default-pie`.